### PR TITLE
[GRDM-31647] GRDMトークン検証処理の追加

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -257,8 +257,10 @@ class BuildHandler(BaseHandler):
             auth_token = self.tokenstore.get_access_token_for(user,
                                                               provider_prefix,
                                                               auth_provider_id)
+            if auth_token is not None and not (await provider.validate_authorized_token(auth_token)):
+                auth_token = None
             repo_token = self.get_argument('repo_token', None)
-            if auth_token is None and repo_token is not None:
+            if repo_token is not None:
                 app_log.info('Repotoken acquired: length={}'.format(len(repo_token)))
                 state = self.tokenstore.new_session(spec, user, provider_prefix, auth_provider_id)
                 self.tokenstore.register_token(user, state, repo_token, None)

--- a/binderhub/repoauth.py
+++ b/binderhub/repoauth.py
@@ -37,7 +37,7 @@ class TokenStore(object):
         c = self.connect.cursor()
         c.execute("""SELECT access_token, expires FROM repo_session
             WHERE user=? AND provider_name=? AND provider_id=? AND access_token IS NOT NULL
-            ORDER BY expires DESC LIMIT 1;""",
+            ORDER BY acquired DESC LIMIT 1;""",
                   (user['name'], provider_name, provider_id))
         result = c.fetchone()
         c.close()


### PR DESCRIPTION
GRDMから発行されたトークンに関して、再利用の際に検証するように修正しました。
これにより、ユーザによりトークンを破棄された場合でも再発行しビルドできるようになります。