### PR TITLE
ユーザ情報取得用URLの変更

### DIFF
--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -122,7 +122,7 @@ class Launcher(LoggingConfigurable):
 
     async def get_user_data(self, username):
         resp = await self.api_request(
-            'users?include_stopped_servers&name_filter=%s' % username,
+            'users/%s?include_stopped_servers' % username,
             method='GET',
         )
         body = json.loads(resp.body.decode('utf-8'))

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -122,7 +122,7 @@ class Launcher(LoggingConfigurable):
 
     async def get_user_data(self, username):
         resp = await self.api_request(
-            'users/%s' % username,
+            'users?include_stopped_servers&name_filter=%s' % username,
             method='GET',
         )
         body = json.loads(resp.body.decode('utf-8'))


### PR DESCRIPTION
JupyterHub APIを使用してユーザ情報を取得する際に、停止中のサーバも含めるようパラメータを付加するよう変更いたしました。