### PR TITLE
[GRDM-28115] 依存先JupyterHubをRCOSDPのものに変更

### DIFF
--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -30,13 +30,23 @@ RUN pip wheel pycurl --wheel-dir ./dist
 
 # The final stage
 # ---------------
-FROM python:3.8-slim-$DIST
+FROM python:3.8-$DIST
 WORKDIR /
+
+ARG DIST
+
+# Install node as required to package binderhub to a wheel
+RUN echo "deb http://deb.nodesource.com/node_14.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
+ && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+RUN apt-get update \
+ && apt-get install --yes \
+        nodejs \
+ && rm -rf /var/lib/apt/lists/*
 
 # The slim version doesn't include git as required by binderhub
 RUN apt-get update \
  && apt-get install --yes \
-        git \
+        git build-essential \
  && rm -rf /var/lib/apt/lists/*
 
 

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -10,5 +10,5 @@ google-cloud-logging==1.*
 
 # jupyterhub and kubernetes is pinned to match the JupyterHub Helm chart's
 # version of jupyterhub
-jupyterhub==1.2.*
+git+https://github.com/RCOSDP/CS-jupyterhub.git@master
 kubernetes==9.*

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -61,7 +61,7 @@ jsonschema==3.2.0
     #   jupyter-telemetry
 jupyter-telemetry==0.1.0
     # via jupyterhub
-jupyterhub==1.2.2
+git+https://github.com/RCOSDP/CS-jupyterhub.git@master
     # via
     #   -r binderhub.in
     #   -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ docker
 escapism
 jinja2
 jsonschema
-jupyterhub
+jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@master
 kubernetes
 prometheus_client
 python-json-logger


### PR DESCRIPTION
Pull Request https://github.com/RCOSDP/CS-jupyterhub/pull/12 に関連して、BinderHubインストール時に依存先としてインストールされるJupyterHubを RCOSDP/CS-jupyterhub のものにする変更です。

従来は jupyterhub/jupyterhub をインストールしていてそれでも問題はなかったのですが、戻り先リンク表示をカスタマイズする関係でBinderHubイメージ中のjupyterhubもRCOSDP/CS-jupyterhubのものに変更をしたいと考えております。