### PR TITLE
Fix test actions

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -33,7 +33,7 @@ jobs:
 
 
       # Install CRD for Argo Rollouts
-      - name: Install Argo Aollouts
+      - name: Install Argo Rollouts
         run: |
           kubectl create namespace argo-rollouts
           kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-            - k3s-channel: v1.19
+            - k3s-version: v1.19.1+k3s1
               helm-version: v3.5.0
               test: main
-            - k3s-channel: v1.19
+            - k3s-version: v1.19.1+k3s1
               helm-version: v3.5.0
               test: auth
-            - k3s-channel: v1.19
+            - k3s-version: v1.19.1+k3s1
               helm-version: v3.5.0
               test: helm
     steps:
@@ -69,6 +69,10 @@ jobs:
         run: |
           kubectl create namespace argo-rollouts
           kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+          curl -LO https://github.com/argoproj/argo-rollouts/releases/latest/download/kubectl-argo-rollouts-linux-amd64
+          chmod +x ./kubectl-argo-rollouts-linux-amd64
+          mv ./kubectl-argo-rollouts-linux-amd64 /usr/local/bin/kubectl-argo-rollouts
+
 
       - name: Setup Python package dependencies
         run: |

--- a/ci/common
+++ b/ci/common
@@ -11,7 +11,7 @@ setup_helm() {
 
 await_jupyterhub() {
     kubectl rollout status --watch --timeout 300s deployment/proxy \
- && kubectl rollout status --watch --timeout 300s deployment/hub \
+ && kubectl-argo-rollouts status --watch --timeout 300s hub \
  && (
         if kubectl get deploy/autohttps > /dev/null 2>&1; then
             kubectl rollout status --watch --timeout 300s deployment/autohttps
@@ -21,5 +21,5 @@ await_jupyterhub() {
 
 await_binderhub() {
     await_jupyterhub
-#   kubectl rollout status --watch --timeout 300s rollout/binder
+    kubectl-argo-rollouts status --watch --timeout 300s binder
 }

--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -25,7 +25,7 @@ you need to add the following into ``config.yaml``:
           binder:
             oauth_no_confirm: true
             oauth_redirect_uri: "http://<binderhub_url>/oauth_callback"
-            oauth_client_id: "binder-oauth-client-test"
+            oauth_client_id: "service-binder-oauth-client-test"
 
       singleuser:
         # to make notebook servers aware of hub

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
   - name: jupyterhub
-    version: "1.1.3-n014.h5eda9d77"
+    version: "2.3.1-20220816"
     repository: "https://rcosdp.github.io/CS-jhub-helm-chart/"

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -30,13 +30,23 @@ RUN pip wheel pycurl --wheel-dir ./dist
 
 # The final stage
 # ---------------
-FROM python:3.8-slim-$DIST
+FROM python:3.8-$DIST
 WORKDIR /
+
+ARG DIST
+
+# Install node as required to package binderhub to a wheel
+RUN echo "deb http://deb.nodesource.com/node_14.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
+ && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+RUN apt-get update \
+ && apt-get install --yes \
+        nodejs \
+ && rm -rf /var/lib/apt/lists/*
 
 # The slim version doesn't include git as required by binderhub
 RUN apt-get update \
  && apt-get install --yes \
-        git \
+        git build-essential \
  && rm -rf /var/lib/apt/lists/*
 
 

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -10,5 +10,5 @@ google-cloud-logging==1.*
 
 # jupyterhub and kubernetes is pinned to match the JupyterHub Helm chart's
 # version of jupyterhub
-jupyterhub==1.2.*
+git+https://github.com/RCOSDP/CS-jupyterhub.git@master
 kubernetes==9.*

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -61,7 +61,7 @@ jsonschema==3.2.0
     #   jupyter-telemetry
 jupyter-telemetry==0.1.0
     # via jupyterhub
-jupyterhub==1.2.2
+git+https://github.com/RCOSDP/CS-jupyterhub.git@master
     # via
     #   -r binderhub.in
     #   -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ docker
 escapism
 jinja2
 jsonschema
-jupyterhub
+jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@master
 kubernetes
 prometheus_client
 python-json-logger

--- a/testing/local-binder-k8s-hub/binderhub_config_auth_additions.py
+++ b/testing/local-binder-k8s-hub/binderhub_config_auth_additions.py
@@ -25,4 +25,4 @@ c.HubOAuth.api_url = c.BinderHub.hub_url + '/hub/api/'
 c.HubOAuth.base_url = c.BinderHub.base_url
 c.HubOAuth.hub_prefix = c.BinderHub.base_url + 'hub/'
 c.HubOAuth.oauth_redirect_uri = 'http://127.0.0.1:8585/oauth_callback'
-c.HubOAuth.oauth_client_id = 'binder-oauth-client-test'
+c.HubOAuth.oauth_client_id = 'service-binder-oauth-client-test'

--- a/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
+++ b/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
@@ -9,9 +9,12 @@ hub:
     binder:
       oauth_no_confirm: true
       oauth_redirect_uri: "http://127.0.0.1:8585/oauth_callback"
-      oauth_client_id: "binder-oauth-client-test"
+      oauth_client_id: "service-binder-oauth-client-test"
   config:
     JupyterHub:
       authenticator_class: "dummy"
+      load_roles:
+        - name: user
+          scopes: [ 'self', 'access:services' ]
     DummyAuthenticator:
       password: "dummy"


### PR DESCRIPTION
PR https://github.com/RCOSDP/CS-binderhub/pull/15 で失敗していたテスト用のGitHub Actionの修正を行いました。
主な修正項目は以下のとおりです。
* kubectl-argo-rollouts 関連で実行できていないコマンドがあったため、必要な設定を追加
* JupyterHub2.3.1 の移行に伴い、認証関係の設定をテスト用コンフィグに追加