### PR TITLE
Kubernetes 1.22以降への対応およびJupyterHubのバージョン変更

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: jupyterhub/action-k3s-helm@v1
         with:
-          k3s-channel: v1.19
+          k3s-channel: v1.22
           metrics-enabled: false
           traefik-enabled: false
           docker-enabled: true

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
   - name: jupyterhub
-    version: "2.3.1-20220816"
+    version: "3.1.0"
     repository: "https://rcosdp.github.io/CS-jhub-helm-chart/"

--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1
@@ -18,6 +20,20 @@ metadata:
   {{- end }}
 spec:
   rules:
+    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: /{{ $.Values.ingress.pathSuffix }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: binder
+                port:
+                  name: http
+    {{- end }}
+    {{- else }}
     {{- range .Values.ingress.hosts }}
     - host: {{ . }}
       http:
@@ -26,6 +42,7 @@ spec:
             backend:
               serviceName: binder
               servicePort: 80
+    {{- end }}
     {{- end }}
   {{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
   tls:
@@ -49,6 +66,8 @@ spec:
 ---
 
 {{- if .Values.ingress.enabled -}}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
@@ -68,6 +87,20 @@ metadata:
   {{- end }}
 spec:
   rules:
+    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+    {{- range .Values.ingress.preview.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: /{{ $.Values.ingress.pathSuffix }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: binder-preview
+                port:
+                  name: http
+    {{- end }}
+    {{- else }}
     {{- range .Values.ingress.preview.hosts }}
     - host: {{ . }}
       http:
@@ -76,6 +109,7 @@ spec:
             backend:
               serviceName: binder-preview
               servicePort: 80
+    {{- end }}
     {{- end }}
   {{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
   tls:

--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -66,9 +66,9 @@ spec:
 ---
 
 {{- if .Values.ingress.enabled -}}
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
Kubernetes 1.22以降でもデプロイ可能なように、Helmチャートの修正を行いました。
また、依存するJupyterHubのバージョンを変更しました。