### PR TITLE
HelmチャートおよびDockerfileの修正

### DIFF
--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
               service:
                 name: binder
                 port:
-                  name: http
+                  number: 80
     {{- end }}
     {{- else }}
     {{- range .Values.ingress.hosts }}
@@ -98,7 +98,7 @@ spec:
               service:
                 name: binder-preview
                 port:
-                  name: http
+                  number: 80
     {{- end }}
     {{- else }}
     {{- range .Values.ingress.preview.hosts }}

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -56,6 +56,12 @@ RUN apt-get update \
 COPY --from=build-stage /tmp/binderhub/dist/*.whl pre-built-wheels/
 COPY helm-chart/images/binderhub/requirements.txt .
 
+RUN pip install --no-cache-dir cliapp
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash 
+RUN apt install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+RUN npm install --global yarn
+
 # Install pre-built wheels and the generated requirements.txt for the image.
 RUN pip install --no-cache-dir \
         pre-built-wheels/*.whl \


### PR DESCRIPTION
microk8s環境にデプロイした際にわかった以下の点に関して、修正を行いました
* Ingress のポート番号の指定にはservice.name ではなく service.numberを使う必要がある
* BinderHubイメージビルド時に jsx のビルドが失敗してしまうため、nodeのバージョンを明示する