### PR TITLE
Allow policy/v1 as apiVersion of PodDisruptionBudget (for k8s >= 1.25)

### DIFF
--- a/helm-chart/binderhub/templates/pdb.yaml
+++ b/helm-chart/binderhub/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.pdb.enabled -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: binderhub


### PR DESCRIPTION
k8s >= 1.25 で、PodDisruptionBudgetのAPIバージョンとしてpolicy/v1beta1 が完全に使用できなくなり、代わりに policy/v1 を使う必要が出てきたため、必要に応じて切り替えるようにHelmチャートを更新しました。

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125