### PR TITLE
#40847 zero-to-jupyterhub-k8sのhelmチャート追随に伴うbinderhub更新作業

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-            - k3s-version: v1.19.1+k3s1
+            - k3s-version: v1.29.0+k3s1
               helm-version: v3.5.0
               test: main
-            - k3s-version: v1.19.1+k3s1
+            - k3s-version: v1.29.0+k3s1
               helm-version: v3.5.0
               test: auth
-            - k3s-version: v1.19.1+k3s1
+            - k3s-version: v1.29.0+k3s1
               helm-version: v3.5.0
               test: helm
     steps:

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
   - name: jupyterhub
-    version: "3.1.0"
+    version: "3.2.1-20240206"
     repository: "https://rcosdp.github.io/CS-jhub-helm-chart/"

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -62,7 +62,7 @@ jupyterhub:
     cors: *cors
     binderauth_enabled: false
   rbac:
-    enabled: true
+    create: true
   hub:
     config:
       JupyterHub:


### PR DESCRIPTION
本家のzero-to-jupyterhub-k8sのタグ 3.2.1をマージ作業に伴い、
binderhub内のjupyterhubバージョンの更新とrbacの設定を変更しました。