### PR TITLE
Fix image cleaner dependencies and update to version 0.2.5-20240816

### DIFF
--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A helm chart to install Binder
 name: binderhub
-version: 0.2.0-jhub-1.1.3
+version: 0.2.5-20240816

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
   - name: jupyterhub
-    version: "3.2.1-20240209"
+    version: "3.2.1-20240401"
     repository: "https://rcosdp.github.io/CS-jhub-helm-chart/"

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -16,7 +16,7 @@ nodeSelector: {}
 
 image:
   name: gcr.io/nii-ap-ops/k8s-binderhub-binderhub
-  tag: '0.2.0-jhub-1.1.3'
+  tag: '0.2.5-20240816'
 
 # registry here is only used to create docker config.json
 registry:
@@ -176,7 +176,7 @@ imageCleaner:
   enabled: true
   image:
     name: gcr.io/nii-ap-ops/k8s-binderhub-image-cleaner
-    tag: '0.2.0-jhub-1.1.3'
+    tag: '0.2.5-20240816'
     repository: gcr.io/nii-ap-ops/k8s-binderhub-image-cleaner
   # delete an image at most every 5 seconds
   delay: 5

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -27,6 +27,9 @@ WORKDIR /tmp/binderhub
 RUN python setup.py bdist_wheel
 RUN pip wheel pycurl --wheel-dir ./dist
 
+# Run the script
+RUN mkdir -p /etc/pki/tls/certs/ && ln -s /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
+
 
 # The final stage
 # ---------------
@@ -49,6 +52,8 @@ RUN apt-get update \
         git build-essential \
  && rm -rf /var/lib/apt/lists/*
 
+# Run the script
+RUN mkdir -p /etc/pki/tls/certs/ && ln -s /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
 
 # Copy the built wheels from the build-stage. Also copy the image
 # requirements.txt built from the binderhub package requirements.txt and the

--- a/helm-chart/images/image-cleaner/requirements.txt
+++ b/helm-chart/images/image-cleaner/requirements.txt
@@ -1,2 +1,2 @@
-docker==4.1.0
+docker>=5.0.0
 kubernetes==10.0.1

--- a/helm-chart/images/image-cleaner/requirements.txt
+++ b/helm-chart/images/image-cleaner/requirements.txt
@@ -1,2 +1,2 @@
-docker>=5.0.0
+docker==7.1.0
 kubernetes==10.0.1

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "file-loader": "^1.1.6",
     "jquery": "^3.2.1",
     "style-loader": "^0.19.1",
-    "webpack": "^3.10.0",
     "xterm": "^2.9.2"
   },
   "scripts": {
@@ -27,5 +26,8 @@
   "bugs": {
     "url": "https://github.com/jupyterhub/binderhub/issues"
   },
-  "homepage": "https://github.com/jupyterhub/binderhub#readme"
+  "homepage": "https://github.com/jupyterhub/binderhub#readme",
+  "dependencies": {
+    "webpack": "^3.12.0"
+  }
 }


### PR DESCRIPTION
## 変更内容

### Helmチャート
- BinderHubのバージョンを0.2.0-jhub-1.1.3から0.2.5-20240816に更新
- イメージクリーナーのタグを0.2.5-20240816に更新

### 依存関係の修正
- イメージクリーナーのdocker依存関係を`>=5.0.0`から`==7.1.0`に固定化
- バージョン固定により、より安定したビルドを実現

### その他
- package.jsonの依存関係の整理

## テスト
- [ ] ローカル環境でのHelmチャートのテスト
- [ ] イメージクリーナーの動作確認

## 関連Issue
該当なし