### PR TITLE
[GRDM-55309]  RDM Providerにおけるハッシュ計算を `.binder` (`binder`) 構成ベースに対応

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -464,7 +464,7 @@ jobs:
 
       - name: Run remote tests
         run: |
-          export BINDER_URL=http://localhost:8000/services/binder/
+          export BINDER_URL=http://localhost:8000/services/binder
           pytest -m remote --cov=binderhub binderhub/tests/
 
       - name: Show hub logs

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -341,6 +341,9 @@ class BuildHandler(BaseHandler):
         else:
             self.repo_token = None
 
+        if self.repo_token and hasattr(provider, "set_access_token"):
+            provider.set_access_token(self.repo_token)
+
         repo_url = self.repo_url = provider.get_repo_url()
 
         # labels to apply to build/launch metrics

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -544,7 +544,7 @@ class CKANProvider(RepoProvider):
         "spec": {"validateRegex": r"[^/]+"},
         "repo": {
             "label": "CKAN dataset URL",
-            "placeholder": "https://demo.ckan.org/dataset/sample-dataset-1",
+            "placeholder": "https://demo.ckan.org/dataset/my-sample-dataset-001",
             "urlEncode": True,
         },
         "ref": {"enabled": False},

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -264,55 +264,86 @@ async def test_ckan(spec, resolved_spec, resolved_ref, resolved_ref_url, build_s
 
 
 @pytest.mark.parametrize(
-    'spec,resolved_ref,repo_url,build_slug,api_status_code,validation_result,token_validation_url',
+    'spec,expected_ref,repo_url,build_slug,api_status_code,validation_result,'
+    'token_validation_url,hash_result,expect_hash_call,expect_uuid',
     [
-        ['https%3A%2F%2Fsome.host.test.jp%2Fpwad2/',
-        None,
-        'https://some.host.test.jp/pwad2',
-        'https---some.host.test.jp-pwad2',
-        None,
-        True,
-        'https://api.some.host.test.jp/v2/nodes/pwad2/'],
-        ['https%3A%2F%2Fsome.host.test.jp%2Fpwad2',
-        None,
-        'https://some.host.test.jp/pwad2',
-        'https---some.host.test.jp-pwad2',
-        404,
-        None,
-        'https://api.some.host.test.jp/v2/nodes/pwad2/'],
-        ['https%3A%2F%2Fsome.host.test.jp%2Fpwad2%2Ffiles%2Ftestprovider%2Ftestdir/',
-        None,
-        'https://some.host.test.jp/pwad2/files/testprovider/testdir',
-        'https---some.host.test.jp-pwad2-files-testprovider-testdir',
-        None,
-        True,
-        'https://api.some.host.test.jp/v2/nodes/pwad2/'],
-        ['https%3A%2F%2Fsome.host.test.jp%2Fpwad2%2Ffiles%2Ftestprovider%2Ftestdir/master',
-        None,
-        'https://some.host.test.jp/pwad2/files/testprovider/testdir',
-        'https---some.host.test.jp-pwad2-files-testprovider-testdir',
-        500,
-        None,
-        'https://api.some.host.test.jp/v2/nodes/pwad2/'],
-        ['https%3A%2F%2Fsome.host.test.jp%2Fpwad2%2Ffiles%2Ftestprovider%2Ftestdir/HEAD',
-        None,
-        'https://some.host.test.jp/pwad2/files/testprovider/testdir',
-        'https---some.host.test.jp-pwad2-files-testprovider-testdir',
-        401,
-        False,
-        'https://api.some.host.test.jp/v2/nodes/pwad2/'],
-        ['https%3A%2F%2Fsome.host.test.jp%2Fpwad2%2Ffiles%2Ftestprovider%2Ftestdir/X1234',
-        'X1234',
-        'https://some.host.test.jp/pwad2/files/testprovider/testdir',
-        'https---some.host.test.jp-pwad2-files-testprovider-testdir',
-        403,
-        False,
-        'https://api.some.host.test.jp/v2/nodes/pwad2/'],
+        [
+            'https%3A%2F%2Fsome.host.test.jp%2Fpwad2/',
+            'computed-hash',
+            'https://some.host.test.jp/pwad2',
+            'https---some.host.test.jp-pwad2',
+            None,
+            True,
+            'https://api.some.host.test.jp/v2/nodes/pwad2/',
+            'computed-hash',
+            True,
+            False,
+        ],
+        [
+            'https%3A%2F%2Fsome.host.test.jp%2Fpwad2',
+            None,
+            'https://some.host.test.jp/pwad2',
+            'https---some.host.test.jp-pwad2',
+            404,
+            None,
+            'https://api.some.host.test.jp/v2/nodes/pwad2/',
+            None,
+            True,
+            True,
+        ],
+        [
+            'https%3A%2F%2Fsome.host.test.jp%2Fpwad2%2Ffiles%2Ftestprovider%2Ftestdir/',
+            'computed-hash',
+            'https://some.host.test.jp/pwad2/files/testprovider/testdir',
+            'https---some.host.test.jp-pwad2-files-testprovider-testdir',
+            None,
+            True,
+            'https://api.some.host.test.jp/v2/nodes/pwad2/',
+            'computed-hash',
+            True,
+            False,
+        ],
+        [
+            'https%3A%2F%2Fsome.host.test.jp%2Fpwad2%2Ffiles%2Ftestprovider%2Ftestdir/master',
+            'computed-hash',
+            'https://some.host.test.jp/pwad2/files/testprovider/testdir',
+            'https---some.host.test.jp-pwad2-files-testprovider-testdir',
+            500,
+            None,
+            'https://api.some.host.test.jp/v2/nodes/pwad2/',
+            'computed-hash',
+            True,
+            False,
+        ],
+        [
+            'https%3A%2F%2Fsome.host.test.jp%2Fpwad2%2Ffiles%2Ftestprovider%2Ftestdir/HEAD',
+            'computed-hash',
+            'https://some.host.test.jp/pwad2/files/testprovider/testdir',
+            'https---some.host.test.jp-pwad2-files-testprovider-testdir',
+            401,
+            False,
+            'https://api.some.host.test.jp/v2/nodes/pwad2/',
+            'computed-hash',
+            True,
+            False,
+        ],
+        [
+            'https%3A%2F%2Fsome.host.test.jp%2Fpwad2%2Ffiles%2Ftestprovider%2Ftestdir/X1234',
+            'X1234',
+            'https://some.host.test.jp/pwad2/files/testprovider/testdir',
+            'https---some.host.test.jp-pwad2-files-testprovider-testdir',
+            403,
+            False,
+            'https://api.some.host.test.jp/v2/nodes/pwad2/',
+            'unused-hash',
+            False,
+            False,
+        ],
     ]
 )
 async def test_rdm(
-    spec, resolved_ref, repo_url, build_slug, api_status_code, validation_result,
-    token_validation_url
+    spec, expected_ref, repo_url, build_slug, api_status_code, validation_result,
+    token_validation_url, hash_result, expect_hash_call, expect_uuid
 ):
     provider = RDMProvider(spec=spec)
     provider.hosts = [
@@ -322,12 +353,22 @@ async def test_rdm(
         }
     ]
 
+    hash_mock = mock.AsyncMock(return_value=hash_result)
+    provider._compute_content_hash = hash_mock
+
     # have to resolve the ref first
     ref = await provider.get_resolved_ref()
-    if resolved_ref is not None:
-        assert ref == resolved_ref
-    else:
+    if expected_ref is not None:
+        assert ref == expected_ref
+    elif expect_uuid:
         assert re.match(r'^[0-9A-Fa-f\-]+$', ref) is not None
+    else:
+        assert ref == hash_result
+
+    if expect_hash_call:
+        assert hash_mock.await_count == 1
+    else:
+        assert hash_mock.await_count == 0
 
     slug = provider.get_build_slug()
     assert slug == build_slug

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -213,11 +213,11 @@ async def test_dataverse(
     "spec,resolved_spec,resolved_ref,resolved_ref_url,build_slug",
     [
         [
-            "https://demo.ckan.org/dataset/sample-dataset-1",
-            "https://demo.ckan.org/dataset/sample-dataset-1",
-            "sample-dataset-1.v",
-            "https://demo.ckan.org/dataset/sample-dataset-1",
-            "ckan-sample-dataset-1",
+            "https://demo.ckan.org/dataset/my-sample-dataset-001",
+            "https://demo.ckan.org/dataset/my-sample-dataset-001",
+            "my-sample-dataset-001.v",
+            "https://demo.ckan.org/dataset/my-sample-dataset-001",
+            "ckan-my-sample-dataset-001",
         ],
         [
             "https://data.depositar.io/dataset/binder-example-sea-turtle-sightings-in-taiwan/?activity_id=93df7fd0-0edc-4ebf-bac7-fbf5f78de90b",

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -188,13 +188,6 @@ async def test_hydroshare_doi():
             "https://doi.org/10.7910/DVN/TJCLKP",
             "dataverse-dvn-2ftjclkp",
         ],
-        [
-            "10.25346/S6/DE95RT",
-            "10.25346/S6/DE95RT",
-            r"20460\.v\d+\.\d+$",
-            "https://doi.org/10.25346/S6/DE95RT",
-            "dataverse-s6-2fde95rt",
-        ],
     ],
 )
 async def test_dataverse(

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,9 +4,9 @@ chartpress>=2.1
 click
 dockerspawner
 jsonschema
-jupyter-repo2docker>=2021.08.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
 jupyter_packaging>=0.10.4,<2
-jupyterhub
+jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
 nest-asyncio
 pytest
 pytest-asyncio<=0.25.0

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -9,7 +9,10 @@ google-cloud-logging==3.*
 
 # jupyterhub and kubernetes is pinned to match the JupyterHub Helm chart's
 # version of jupyterhub
-git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
+jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
+
+# jupyter-repo2docker is pinned to CS-repo2docker
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
 
 # Workaround: Added a dependecy of ruamel-yaml because jupyter-telemetry,
 # which has a dependency of ruamel-yaml, was removed from jupyterhub.

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -4,99 +4,129 @@
 #
 #    Use the "Run workflow" button at https://github.com/jupyterhub/binderhub/actions/workflows/watch-dependencies.yaml
 #
-alembic==1.14.1
+aiofiles==25.1.0
+    # via osfclient
+alembic==1.17.1
     # via jupyterhub
 annotated-types==0.7.0
     # via pydantic
-arrow==1.3.0
+anyio==4.11.0
+    # via httpx
+arrow==1.4.0
     # via isoduration
-attrs==25.1.0
+attrs==25.4.0
     # via
     #   jsonschema
     #   referencing
-cachetools==5.5.1
+beautifulsoup4==4.14.2
+    # via jupyter-repo2docker
+cachetools==6.2.1
     # via google-auth
-certifi==2025.1.31
+certifi==2025.10.5
     # via
+    #   httpcore
+    #   httpx
     #   kubernetes
     #   requests
-certipy==0.2.1
+certipy==0.2.2
     # via jupyterhub
-cffi==1.17.1
+cffi==2.0.0
     # via cryptography
-charset-normalizer==3.4.1
+chardet==5.2.0
+    # via jupyter-repo2docker
+charset-normalizer==3.4.4
     # via requests
-cryptography==44.0.0
+cryptography==46.0.3
     # via certipy
-deprecated==1.2.18
-    # via opentelemetry-api
 docker==7.1.0
-    # via -r helm-chart/images/binderhub/../../../requirements.txt
+    # via
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
+    #   jupyter-repo2docker
+entrypoints==0.4
+    # via jupyter-repo2docker
 escapism==1.0.1
-    # via -r helm-chart/images/binderhub/../../../requirements.txt
+    # via
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
+    #   jupyter-repo2docker
 fqdn==1.5.1
     # via jsonschema
-google-api-core==2.24.1
+google-api-core==2.28.1
     # via
     #   google-cloud-appengine-logging
     #   google-cloud-core
     #   google-cloud-logging
-google-auth==2.38.0
+google-auth==2.42.1
     # via
     #   google-api-core
     #   google-cloud-appengine-logging
     #   google-cloud-core
     #   google-cloud-logging
     #   kubernetes
-google-cloud-appengine-logging==1.5.0
+google-cloud-appengine-logging==1.7.0
     # via google-cloud-logging
-google-cloud-audit-log==0.3.0
+google-cloud-audit-log==0.4.0
     # via google-cloud-logging
-google-cloud-core==2.4.1
+google-cloud-core==2.5.0
     # via google-cloud-logging
-google-cloud-logging==3.11.4
+google-cloud-logging==3.12.1
     # via -r helm-chart/images/binderhub/requirements.in
-googleapis-common-protos==1.66.0
+googleapis-common-protos==1.71.0
     # via
     #   google-api-core
     #   google-cloud-audit-log
     #   grpc-google-iam-v1
     #   grpcio-status
-greenlet==3.1.1
+greenlet==3.2.4
     # via sqlalchemy
-grpc-google-iam-v1==0.14.0
+grpc-google-iam-v1==0.14.3
     # via google-cloud-logging
-grpcio==1.70.0
+grpcio==1.76.0
     # via
     #   google-api-core
+    #   google-cloud-appengine-logging
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.70.0
+grpcio-status==1.76.0
     # via google-api-core
-idna==3.10
+h11==0.16.0
+    # via httpcore
+httpcore==1.0.9
+    # via httpx
+httpx==0.28.1
+    # via osfclient
+idna==3.11
     # via
+    #   anyio
+    #   httpx
     #   jsonschema
     #   jupyterhub
     #   requests
-importlib-metadata==8.5.0
+importlib-metadata==8.7.0
     # via opentelemetry-api
+iso8601==2.1.0
+    # via jupyter-repo2docker
 isoduration==20.11.0
     # via jsonschema
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
+    #   jupyter-repo2docker
     #   jupyterhub
 jsonpointer==3.0.0
     # via jsonschema
-jsonschema==4.23.0
+jsonschema==4.25.1
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyter-events
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.9.1
     # via jsonschema
-jupyter-events==0.11.0
+jupyter-events==0.12.0
     # via jupyterhub
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+    # via
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
+    #   -r helm-chart/images/binderhub/requirements.in
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
@@ -105,33 +135,39 @@ kubernetes==9.0.1
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   -r helm-chart/images/binderhub/requirements.in
-mako==1.3.8
+lark==1.3.1
+    # via rfc3987-syntax
+mako==1.3.10
     # via alembic
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   jinja2
     #   mako
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyterhub
     #   requests-oauthlib
-opentelemetry-api==1.29.0
+opentelemetry-api==1.38.0
     # via google-cloud-logging
-packaging==24.2
-    # via jupyterhub
+osfclient @ git+https://github.com/RCOSDP/rdmclient.git@master
+    # via jupyter-repo2docker
+packaging==25.0
+    # via
+    #   jupyter-events
+    #   jupyterhub
 pamela==1.2.0
     # via jupyterhub
-prometheus-client==0.21.1
+prometheus-client==0.23.1
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyterhub
-proto-plus==1.26.0
+proto-plus==1.26.1
     # via
     #   google-api-core
     #   google-cloud-appengine-logging
     #   google-cloud-logging
-protobuf==5.29.3
+protobuf==6.33.0
     # via
     #   google-api-core
     #   google-cloud-appengine-logging
@@ -145,15 +181,15 @@ pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via google-auth
-pycparser==2.22
+pycparser==2.23
     # via cffi
-pycurl==7.45.4
+pycurl==7.45.7
     # via -r helm-chart/images/binderhub/requirements.in
-pydantic==2.10.6
+pydantic==2.12.3
     # via jupyterhub
-pydantic-core==2.27.2
+pydantic-core==2.41.4
     # via pydantic
 pyjwt==2.10.1
     # via -r helm-chart/images/binderhub/../../../requirements.txt
@@ -162,23 +198,26 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   jupyterhub
     #   kubernetes
-python-json-logger==3.2.1
+    #   osfclient
+python-json-logger==4.0.0
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyter-events
-pyyaml==6.0.2
+    #   jupyter-repo2docker
+pyyaml==6.0.3
     # via
     #   jupyter-events
     #   kubernetes
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-requests==2.32.3
+requests==2.32.5
     # via
     #   docker
     #   google-api-core
+    #   jupyter-repo2docker
     #   jupyterhub
     #   kubernetes
     #   requests-oauthlib
@@ -192,60 +231,83 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rpds-py==0.22.3
+rfc3987-syntax==1.1.0
+    # via jsonschema
+rpds-py==0.28.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
+rsa==4.9.1
     # via google-auth
-ruamel-yaml==0.18.10
-    # via -r helm-chart/images/binderhub/requirements.in
-ruamel-yaml-clib==0.2.12
+ruamel-yaml==0.18.16
+    # via
+    #   -r helm-chart/images/binderhub/requirements.in
+    #   jupyter-repo2docker
+ruamel-yaml-clib==0.2.14
     # via ruamel-yaml
+semver==3.0.4
+    # via jupyter-repo2docker
 six==1.17.0
     # via
     #   kubernetes
+    #   osfclient
     #   python-dateutil
     #   rfc3339-validator
-sqlalchemy==2.0.37
+sniffio==1.3.1
+    # via anyio
+soupsieve==2.8
+    # via beautifulsoup4
+sqlalchemy==2.0.44
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   alembic
     #   jupyterhub
-tornado==6.4.2
+toml==0.10.2
+    # via jupyter-repo2docker
+tornado==6.5.2
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyterhub
+tqdm==4.67.1
+    # via osfclient
 traitlets==5.14.3
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyter-events
+    #   jupyter-repo2docker
     #   jupyterhub
-types-python-dateutil==2.9.0.20241206
-    # via arrow
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via
     #   alembic
+    #   anyio
+    #   beautifulsoup4
+    #   grpcio
+    #   opentelemetry-api
     #   pydantic
     #   pydantic-core
     #   referencing
     #   sqlalchemy
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via pydantic
+tzdata==2025.2
+    # via arrow
+tzlocal==5.3.1
+    # via osfclient
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.3.0
+urllib3==2.5.0
     # via
     #   docker
     #   kubernetes
     #   requests
-webcolors==24.11.1
+webcolors==25.10.0
     # via jsonschema
-websocket-client==1.8.0
+websocket-client==1.9.0
     # via kubernetes
-wrapt==1.17.2
-    # via deprecated
-zipp==3.21.0
+zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.8.0
+setuptools==80.9.0
     # via kubernetes

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ escapism
 jinja2
 jsonschema
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
 kubernetes
 prometheus_client
 pyjwt>=2

--- a/testing/local-binder-local-hub/requirements.txt
+++ b/testing/local-binder-local-hub/requirements.txt
@@ -1,3 +1,3 @@
 dockerspawner>=12
-jupyter-repo2docker>=2023.06.0
-jupyterhub>=3
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1


### PR DESCRIPTION
RDM Providerにおけるハッシュ計算を `.binder` (`binder`) 構成ベースに対応します。 https://github.com/RCOSDP/CS-repo2docker/pull/22 の変更を利用するようにします。

最新repo2docker(`2025.10.0`)はイメージ作成時はデータは取り込まず、Jupyter Server起動時に取り込む仕様に変更になりました。そのため、JupyterHubのSpawner設定では以下のコマンドで `provision.sh`の取り込みを行う必要がある点に留意ください。

```
class Binder**Spawner(KubeSpawner):
...
    cmd = [
        'bash', '-c',
        """
set -e

# Find and execute provision.sh if it exists
for path in \
    "${REPO_DIR}/binder/provision.sh" \
    "${REPO_DIR}/.binder/provision.sh" \
    "$HOME/binder/provision.sh" \
    "$HOME/.binder/provision.sh"; do

    if [ -f "$path" ]; then
        echo "[provision-wrapper] Executing: $path" >&2
        exec bash "$path" "$@"
    fi
done

# No provision.sh found, start normally
exec "$@"
        """,
        '--', 'jupyterhub-singleuser'
    ]
...
```