### PR TITLE
Update CS-repo2docker to 2026.02.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -457,10 +457,10 @@ jobs:
         run: |
           cd testing/local-binder-local-hub
           jupyterhub --config=jupyterhub_config.py > jupyterhub.log 2>&1 &
-          sleep 5
+          sleep 15
 
           echo curl http://localhost:8000/hub/api/ should print the JupyterHub version
-          curl http://localhost:8000/hub/api/ --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body --retry-all-errors
+          curl http://localhost:8000/hub/api/ --max-time 10 --retry 5 --retry-delay 3 --retry-connrefused --fail-with-body --retry-all-errors
 
       - name: Run remote tests
         run: |

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -357,7 +357,7 @@ class FigshareProvider(RepoProvider):
         "ref": {"enabled": False},
     }
 
-    url_regex = re.compile(r"(.*)/articles/([^/]+)/([^/]+)/(\d+)(/)?(\d+)?")
+    url_regex = re.compile(r"(.*)/articles/([^/]+)/(\d+)(/)?(\d+)?")
 
     async def get_resolved_ref(self):
         client = AsyncHTTPClient()
@@ -365,8 +365,8 @@ class FigshareProvider(RepoProvider):
         r = await client.fetch(req)
 
         match = self.url_regex.match(r.effective_url)
-        article_id = match.groups()[3]
-        article_version = match.groups()[5]
+        article_id = match.groups()[2]
+        article_version = match.groups()[4]
         if not article_version:
             article_version = "1"
         self.record_id = f"{article_id}.v{article_version}"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ chartpress>=2.1
 click
 dockerspawner
 jsonschema
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
 jupyter_packaging>=0.10.4,<2
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
 nest-asyncio

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -12,7 +12,7 @@ google-cloud-logging==3.*
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
 
 # jupyter-repo2docker is pinned to CS-repo2docker
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
 
 # Workaround: Added a dependecy of ruamel-yaml because jupyter-telemetry,
 # which has a dependency of ruamel-yaml, was removed from jupyterhub.

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -123,7 +123,7 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-events==0.12.0
     # via jupyterhub
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   -r helm-chart/images/binderhub/requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ escapism
 jinja2
 jsonschema
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
 kubernetes
 prometheus_client
 pyjwt>=2

--- a/testing/local-binder-local-hub/requirements.txt
+++ b/testing/local-binder-local-hub/requirements.txt
@@ -1,3 +1,3 @@
 dockerspawner>=12
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2025.10.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1


### PR DESCRIPTION
# 変更

CS-repo2dockerのバージョンを2026.02.0に更新するとともに、以下2点の修正をするPRです。

1. FigShareのURL構造の変更に伴って失敗するようになったテストの修正 -- upstreamの[コミット c2ad98e](https://github.com/jupyterhub/binderhub/commit/c2ad98e4e30e152a123d18d53d9ad52d0ccbc7b4)
2. テスト時のJupyterHubの起動を待つ時間を長くして偶然にテストが失敗する可能性を小さくした

1.についてはupstreamの[PR#2205](https://github.com/jupyterhub/binderhub/pull/2055)としてマージ済みのコミットです。