### PR TITLE
Update CS-repo2docker to 2026.06.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ chartpress>=2.1
 click
 dockerspawner
 jsonschema
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.06.0
 jupyter_packaging>=0.10.4,<2
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
 nest-asyncio

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -12,7 +12,7 @@ google-cloud-logging==3.*
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
 
 # jupyter-repo2docker is pinned to CS-repo2docker
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.06.0
 
 # Workaround: Added a dependecy of ruamel-yaml because jupyter-telemetry,
 # which has a dependency of ruamel-yaml, was removed from jupyterhub.

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -127,7 +127,7 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-events==0.12.0
     # via jupyterhub
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.06.0
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   -r helm-chart/images/binderhub/requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ escapism
 jinja2
 jsonschema
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.06.0
 kubernetes
 prometheus_client
 pyjwt>=2

--- a/testing/local-binder-local-hub/requirements.txt
+++ b/testing/local-binder-local-hub/requirements.txt
@@ -1,3 +1,3 @@
 dockerspawner>=12
-jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.02.0
+jupyter-repo2docker @ git+https://github.com/RCOSDP/CS-repo2docker.git@2026.06.0
 jupyterhub @ git+https://github.com/RCOSDP/CS-jupyterhub.git@5.2.1


### PR DESCRIPTION
CS-repo2dockerを2026.06.0に更新するPRです。